### PR TITLE
Added support for .env variables via 'dotenv-safe'

### DIFF
--- a/web-app/.env.example
+++ b/web-app/.env.example
@@ -1,0 +1,8 @@
+# .env.example, details should be set in a ordinary .env file
+
+# --- database ---
+
+DB_USERNAME=
+DB_PASSWORD=
+DB_DATABASE=
+DB_HOST=

--- a/web-app/.sequelizerc
+++ b/web-app/.sequelizerc
@@ -1,7 +1,7 @@
 const path = require('path');
 
 module.exports = {
-  'config': path.resolve('src', 'config', 'database.json'),
+  'config': path.resolve('src', 'config', 'database.js'),
   'models-path': path.resolve('src', 'data-access-layer', 'models'),
   'seeders-path': path.resolve('src', 'data-access-layer', 'seeders'),
   'migrations-path': path.resolve('src', 'data-access-layer', 'migrations')

--- a/web-app/Dockerfile
+++ b/web-app/Dockerfile
@@ -2,6 +2,7 @@ FROM node:13.6.0
 
 WORKDIR /web-app/
 
+COPY .env* ./
 COPY .sequelizerc ./
 COPY package*.json ./
 

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -437,6 +437,19 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
+    "dotenv-safe": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-safe/-/dotenv-safe-8.2.0.tgz",
+      "integrity": "sha512-uWwWWdUQkSs5a3mySDB22UtNwyEYi0JtEQu+vDzIqr9OjbDdC2Ip13PnSpi/fctqlYmzkxCeabiyCAOROuAIaA==",
+      "requires": {
+        "dotenv": "^8.2.0"
+      }
+    },
     "dottie": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -4,13 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon --inspect=0.0.0.0 src/app.js",
+    "start": "nodemon -r dotenv-safe/config --inspect=0.0.0.0 src/app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "connect-redis": "^4.0.3",
+    "dotenv-safe": "^8.2.0",
     "express": "^4.17.1",
     "express-handlebars": "^3.1.0",
     "express-session": "^1.17.0",

--- a/web-app/src/config/database.js
+++ b/web-app/src/config/database.js
@@ -1,9 +1,11 @@
-{
+require('dotenv-safe').config();
+
+module.exports = {
   "development": {
-    "username": "root",
-    "password": "test123",
-    "database": "web-app",
-    "host": "db",
+    "username": process.env.DB_USERNAME,
+    "password": process.env.DB_PASSWORD,
+    "database": process.env.DB_DATABASE,
+    "host": process.env.DB_HOST,
     "dialect": "mysql",
     "operatorsAliases": false
   },

--- a/web-app/src/data-access-layer/connection.js
+++ b/web-app/src/data-access-layer/connection.js
@@ -1,7 +1,7 @@
 const Sequelize = require("sequelize");
 
-const sequelize = new Sequelize('web-app', 'root', 'test123', {
-    host: 'db',
+const sequelize = new Sequelize(process.env.DB_DATABASE, process.env.DB_USERNAME, process.env.DB_PASSWORD, {
+    host: process.env.DB_HOST,
     dialect: 'mysql'
 });
 


### PR DESCRIPTION
Support for creating enviroment variables in a _.env_ file has been added via the library 'dotenv-safe'. The variables will be generated and put inside the _.js_ **process.env** object:

- **process.env**.ENVIROMENT_VARIABLE

For more information:

https://github.com/sequelize/sequelize
https://github.com/sequelize/cli